### PR TITLE
Fix invalid runbook

### DIFF
--- a/day15/json.yml
+++ b/day15/json.yml
@@ -45,5 +45,5 @@ steps:
           body:
             application/json: null
     test: |
-      # ステータスコードが204であること
-      current.res.status == 204
+      # ステータスコードが200であること
+      current.res.status == 200

--- a/day16/json-template.yml
+++ b/day16/json-template.yml
@@ -40,5 +40,5 @@ steps:
           body:
             application/json: null
     test: |
-      # ステータスコードが204であること
-      current.res.status == 204
+      # ステータスコードが200であること
+      current.res.status == 200

--- a/day17/dump-and-verify.yml
+++ b/day17/dump-and-verify.yml
@@ -19,5 +19,5 @@ steps:
       current.res.status == 200
       # 記事の件数が正しいこと
       && len(current.res.body.articles) == vars.count
-      # dumpしたレスポンス（前回の結果）と同じこと
+      # dumpしたレスポンス (前回の結果) と同じこと
       && compare(current.res.body, vars.response)


### PR DESCRIPTION
[runnチュートリアル](https://zenn.dev/katzumi/books/runn-tutorial)を通してみて、手元で通らなかったテストが3つあったので対処した内容を PR にしました。

- Zenn の Scrap 削除の API を実行した際の Response Code は 200 が返るように変更されていたようだったので、Chapter 16、Chapter 17 の runbook を修正しました
- Chapter 18 の runbook の実行時に以下のエラーが発生したため、全角括弧を半角スペースと半角括弧に変更しました
```
Failure/Error: test failed on "dumpしたjsonを検証する".steps.listArticles "指定された件数分、記事一覧を取得します": eval error: unrecognized character: U+FF08 '（' (5:14)
```

実行環境
```
> runn -v
runn version 0.121.1

> sw_vers
ProductName:		macOS
ProductVersion:		14.6.1
BuildVersion:		23G93
```
